### PR TITLE
Revert "FLEX-2915 Removes NewOrganisationIdentification"

### DIFF
--- a/osgp-ws-admin/src/main/resources/schemas/devicemanagement.xsd
+++ b/osgp-ws-admin/src/main/resources/schemas/devicemanagement.xsd
@@ -56,6 +56,8 @@
     <xsd:complexType>
       <xsd:sequence>
         <xsd:element name="OrganisationIdentification" type="common:Identification" />
+        <xsd:element name="NewOrganisationIdentification"
+          type="common:Identification" />
         <xsd:element name="NewOrganisationName" type="xsd:string" />
         <xsd:element name="NewOrganisationPlatformFunctionGroup"
           type="tns:PlatformFunctionGroup" />


### PR DESCRIPTION
Reverts OSGP/Shared#183. It should be merged at the same time as the other pull requests for FLEX-2915.