### PR TITLE
FLEX-2915 ~ Removes NewOrganisationIdentification

### DIFF
--- a/osgp-ws-admin/src/main/resources/schemas/devicemanagement.xsd
+++ b/osgp-ws-admin/src/main/resources/schemas/devicemanagement.xsd
@@ -56,8 +56,6 @@
     <xsd:complexType>
       <xsd:sequence>
         <xsd:element name="OrganisationIdentification" type="common:Identification" />
-        <xsd:element name="NewOrganisationIdentification"
-          type="common:Identification" />
         <xsd:element name="NewOrganisationName" type="xsd:string" />
         <xsd:element name="NewOrganisationPlatformFunctionGroup"
           type="tns:PlatformFunctionGroup" />


### PR DESCRIPTION
Same change as merged before. The initial merge was reverted, because the related pull requests couldn't be merged yet.