### PR TITLE
FLEX-3258 ~ Fixes mapping from XML date time to Yoda date time.

### DIFF
--- a/shared/src/main/java/com/alliander/osgp/shared/mappers/XMLGregorianCalendarToDateTimeConverter.java
+++ b/shared/src/main/java/com/alliander/osgp/shared/mappers/XMLGregorianCalendarToDateTimeConverter.java
@@ -52,6 +52,12 @@ public class XMLGregorianCalendarToDateTimeConverter extends BidirectionalConver
 
     @Override
     public boolean canConvert(final Type<?> sourceType, final Type<?> destinationType) {
+        // The check 'this.sourceType.isAssignableFrom(sourceType)' fails for
+        // org.yoda.DateTime.class.
+        // Use custom check instead.
+        if (sourceType.getRawType().getName() == DateTime.class.getName()) {
+            return true;
+        }
         return this.sourceType.isAssignableFrom(sourceType) && this.destinationType.equals(destinationType);
     }
 

--- a/shared/src/main/java/com/alliander/osgp/shared/mappers/XMLGregorianCalendarToDateTimeConverter.java
+++ b/shared/src/main/java/com/alliander/osgp/shared/mappers/XMLGregorianCalendarToDateTimeConverter.java
@@ -55,7 +55,8 @@ public class XMLGregorianCalendarToDateTimeConverter extends BidirectionalConver
         // The check 'this.sourceType.isAssignableFrom(sourceType)' fails for
         // org.yoda.DateTime.class.
         // Use custom check instead.
-        if (sourceType.getRawType().getName() == DateTime.class.getName()) {
+        if (sourceType.getRawType().getName() == DateTime.class.getName()
+                && destinationType.getRawType().getName() == XMLGregorianCalendar.class.getName()) {
             return true;
         }
         return this.sourceType.isAssignableFrom(sourceType) && this.destinationType.equals(destinationType);

--- a/shared/src/main/java/com/alliander/osgp/shared/mappers/XMLGregorianCalendarToDateTimeConverter.java
+++ b/shared/src/main/java/com/alliander/osgp/shared/mappers/XMLGregorianCalendarToDateTimeConverter.java
@@ -11,13 +11,13 @@ import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 
-import org.joda.time.DateTime;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import ma.glasnost.orika.MappingContext;
 import ma.glasnost.orika.converter.BidirectionalConverter;
 import ma.glasnost.orika.metadata.Type;
+
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class XMLGregorianCalendarToDateTimeConverter extends BidirectionalConverter<XMLGregorianCalendar, DateTime> {
 
@@ -48,6 +48,11 @@ public class XMLGregorianCalendarToDateTimeConverter extends BidirectionalConver
         }
 
         return new DateTime(source.toGregorianCalendar().getTime());
+    }
+
+    @Override
+    public boolean canConvert(final Type<?> sourceType, final Type<?> destinationType) {
+        return this.sourceType.isAssignableFrom(sourceType) && this.destinationType.equals(destinationType);
     }
 
 }

--- a/shared/src/test/java/com/alliander/osgp/shared/XMLGregorianCalendarToDateTimeConverterTest.java
+++ b/shared/src/test/java/com/alliander/osgp/shared/XMLGregorianCalendarToDateTimeConverterTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2017 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.alliander.osgp.shared;
+
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import ma.glasnost.orika.MapperFacade;
+import ma.glasnost.orika.MapperFactory;
+import ma.glasnost.orika.impl.DefaultMapperFactory;
+
+import org.joda.time.DateTime;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.alliander.osgp.shared.mappers.XMLGregorianCalendarToDateTimeConverter;
+
+public class XMLGregorianCalendarToDateTimeConverterTest {
+
+    private final MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+    private MapperFacade mapper;
+
+    @Before
+    public void before() {
+        this.mapperFactory.getConverterFactory().registerConverter(new XMLGregorianCalendarToDateTimeConverter());
+        this.mapper = this.mapperFactory.getMapperFacade();
+    }
+
+    @Test
+    public void test1() {
+        try {
+            final DateTime dateTime = DateTime.now();
+            final XMLGregorianCalendar xmlGregorianCalendar = DatatypeFactory.newInstance().newXMLGregorianCalendar(
+                    dateTime.toGregorianCalendar());
+
+            // Try to map to Yoda version.
+            final DateTime mappedYodaDateTime = this.mapper.map(xmlGregorianCalendar, DateTime.class);
+            Assert.assertEquals(dateTime, mappedYodaDateTime);
+        } catch (final DatatypeConfigurationException e) {
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void test2() {
+        try {
+            final DateTime dateTime = DateTime.now();
+            final XMLGregorianCalendar xmlGregorianCalendar = DatatypeFactory.newInstance().newXMLGregorianCalendar(
+                    dateTime.toGregorianCalendar());
+
+            // Try to map to XML version.
+            final XMLGregorianCalendar mappedXMLGregorianCalendar = this.mapper.map(dateTime,
+                    XMLGregorianCalendar.class);
+            Assert.assertEquals(xmlGregorianCalendar, mappedXMLGregorianCalendar);
+        } catch (final DatatypeConfigurationException e) {
+            Assert.fail(e.getMessage());
+        }
+    }
+}

--- a/shared/src/test/java/com/alliander/osgp/shared/XMLGregorianCalendarToDateTimeConverterTest.java
+++ b/shared/src/test/java/com/alliander/osgp/shared/XMLGregorianCalendarToDateTimeConverterTest.java
@@ -13,7 +13,10 @@ import javax.xml.datatype.XMLGregorianCalendar;
 
 import ma.glasnost.orika.MapperFacade;
 import ma.glasnost.orika.MapperFactory;
+import ma.glasnost.orika.MappingContext;
+import ma.glasnost.orika.converter.BidirectionalConverter;
 import ma.glasnost.orika.impl.DefaultMapperFactory;
+import ma.glasnost.orika.metadata.Type;
 
 import org.joda.time.DateTime;
 import org.junit.Assert;
@@ -24,17 +27,48 @@ import com.alliander.osgp.shared.mappers.XMLGregorianCalendarToDateTimeConverter
 
 public class XMLGregorianCalendarToDateTimeConverterTest {
 
+    /**
+     * Simple converter implementation used to test mapping strategies.
+     */
+    private class DateTimeToStringConverter extends BidirectionalConverter<DateTime, String> {
+
+        @Override
+        public String convertTo(final DateTime source, final Type<String> destinationType,
+                final MappingContext mappingContext) {
+            if (source == null) {
+                return null;
+            }
+            return source.toString();
+        }
+
+        @Override
+        public DateTime convertFrom(final String source, final Type<DateTime> destinationType,
+                final MappingContext mappingContext) {
+            if (source == null) {
+                return null;
+            }
+            return DateTime.parse(source);
+        }
+
+    }
+
     private final MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
     private MapperFacade mapper;
 
+    /**
+     * Register {@link XMLGregorianCalendarToDateTimeConverter} and
+     * {@link DateTimeToStringConverter}. The former is the class under test.
+     * The latter is just part of the unit tests.
+     */
     @Before
     public void before() {
         this.mapperFactory.getConverterFactory().registerConverter(new XMLGregorianCalendarToDateTimeConverter());
+        this.mapperFactory.getConverterFactory().registerConverter(new DateTimeToStringConverter());
         this.mapper = this.mapperFactory.getMapperFacade();
     }
 
     @Test
-    public void test1() {
+    public void mapXMLGregorianCalenderToDateTime() {
         try {
             final DateTime dateTime = DateTime.now();
             final XMLGregorianCalendar xmlGregorianCalendar = DatatypeFactory.newInstance().newXMLGregorianCalendar(
@@ -49,7 +83,7 @@ public class XMLGregorianCalendarToDateTimeConverterTest {
     }
 
     @Test
-    public void test2() {
+    public void mapDateTimeToXMLGregorianCalender() {
         try {
             final DateTime dateTime = DateTime.now();
             final XMLGregorianCalendar xmlGregorianCalendar = DatatypeFactory.newInstance().newXMLGregorianCalendar(
@@ -62,5 +96,23 @@ public class XMLGregorianCalendarToDateTimeConverterTest {
         } catch (final DatatypeConfigurationException e) {
             Assert.fail(e.getMessage());
         }
+    }
+
+    @Test
+    public void mapStringToDateTime() {
+        final String stringTime = DateTime.now().toString();
+
+        // Try to map to Yoda version.
+        final DateTime mappedYodaTime = this.mapper.map(stringTime, DateTime.class);
+        Assert.assertNotNull("Not expecting NULL but a DateTime instance.", mappedYodaTime);
+    }
+
+    @Test
+    public void mapDateTimeToString() {
+        final DateTime dateTime = DateTime.now();
+
+        // Try to map to String version.
+        final String mappedStringTime = this.mapper.map(dateTime, String.class);
+        Assert.assertNotNull("Not expecting NULL but a date time as string.", mappedStringTime);
     }
 }


### PR DESCRIPTION
- this issue was detected by tariff schedules which contained wrong dates
- the issue is caused by the XMLGregorianCalendarToDateTimeConverter
- since XMLGregorianCalendarToDateTimeConverter is used to convert all DateTime instances, this fix should resolve anything which depends on converting dates