### PR TITLE
SLIM-FIX ReadAlarmRegister does not extend superclasses

### DIFF
--- a/osgp-ws-smartmetering/src/main/resources/schemas/sm-monitoring.xsd
+++ b/osgp-ws-smartmetering/src/main/resources/schemas/sm-monitoring.xsd
@@ -240,18 +240,17 @@
 
   <xsd:element name="ReadAlarmRegisterAsyncResponse">
     <xsd:complexType>
-      <xsd:sequence>
-        <xsd:element name="AsyncResponse" type="common:AsyncResponse" />
-      </xsd:sequence>
+    <xsd:complexContent>
+        <xsd:extension base="common:AsyncResponse"></xsd:extension>
+      </xsd:complexContent>
     </xsd:complexType>
   </xsd:element>
 
   <xsd:element name="ReadAlarmRegisterAsyncRequest">
     <xsd:complexType>
-      <xsd:sequence>
-        <xsd:element name="DeviceIdentification" type="common:DeviceIdentification" minOccurs="1" />
-        <xsd:element name="CorrelationUid" type="common:CorrelationUid" minOccurs="1" />
-      </xsd:sequence>
+      <xsd:complexContent>
+        <xsd:extension base="common:AsyncRequest"></xsd:extension>
+      </xsd:complexContent>
     </xsd:complexType>
   </xsd:element>
 


### PR DESCRIPTION
Make ReadAlarmRegisterAsyncResponse extend AsyncResponse and
ReadAlarmRegisterAsyncRequest extend AsyncRequest