### PR TITLE
SLIM-1534 Deals with PeriodicMeterReadsResponseItemDto constructor

### DIFF
--- a/osgp-dto/src/main/java/com/alliander/osgp/dto/valueobjects/smartmetering/ActiveEnergyValuesDto.java
+++ b/osgp-dto/src/main/java/com/alliander/osgp/dto/valueobjects/smartmetering/ActiveEnergyValuesDto.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2018 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.alliander.osgp.dto.valueobjects.smartmetering;
+
+public class ActiveEnergyValuesDto {
+
+    private final DlmsMeterValueDto activeEnergyImport;
+    private final DlmsMeterValueDto activeEnergyExport;
+    private final DlmsMeterValueDto activeEnergyImportTariffOne;
+    private final DlmsMeterValueDto activeEnergyImportTariffTwo;
+    private final DlmsMeterValueDto activeEnergyExportTariffOne;
+    private final DlmsMeterValueDto activeEnergyExportTariffTwo;
+
+    public ActiveEnergyValuesDto(final DlmsMeterValueDto activeEnergyImport, final DlmsMeterValueDto activeEnergyExport,
+            final DlmsMeterValueDto activeEnergyImportTariffOne, final DlmsMeterValueDto activeEnergyImportTariffTwo,
+            final DlmsMeterValueDto activeEnergyExportTariffOne, final DlmsMeterValueDto activeEnergyExportTariffTwo) {
+
+        this.activeEnergyImport = activeEnergyImport;
+        this.activeEnergyImportTariffOne = activeEnergyImportTariffOne;
+        this.activeEnergyImportTariffTwo = activeEnergyImportTariffTwo;
+        this.activeEnergyExport = activeEnergyExport;
+        this.activeEnergyExportTariffOne = activeEnergyExportTariffOne;
+        this.activeEnergyExportTariffTwo = activeEnergyExportTariffTwo;
+    }
+
+    @Override
+    public String toString() {
+        return "ActiveEnergyValues[import=" + this.activeEnergyImport + ", export=" + this.activeEnergyExport
+                + ", importTariffOne=" + this.activeEnergyImportTariffOne + ", importTariffTwo="
+                + this.activeEnergyImportTariffTwo + ", exportTariffOne=" + this.activeEnergyExportTariffOne
+                + ", exportTariffTwo=" + this.activeEnergyExportTariffTwo + "]";
+    }
+
+    public DlmsMeterValueDto getActiveEnergyImport() {
+        return this.activeEnergyImport;
+    }
+
+    public DlmsMeterValueDto getActiveEnergyExport() {
+        return this.activeEnergyExport;
+    }
+
+    public DlmsMeterValueDto getActiveEnergyImportTariffOne() {
+        return this.activeEnergyImportTariffOne;
+    }
+
+    public DlmsMeterValueDto getActiveEnergyImportTariffTwo() {
+        return this.activeEnergyImportTariffTwo;
+    }
+
+    public DlmsMeterValueDto getActiveEnergyExportTariffOne() {
+        return this.activeEnergyExportTariffOne;
+    }
+
+    public DlmsMeterValueDto getActiveEnergyExportTariffTwo() {
+        return this.activeEnergyExportTariffTwo;
+    }
+}

--- a/osgp-dto/src/main/java/com/alliander/osgp/dto/valueobjects/smartmetering/ActiveEnergyValuesDto.java
+++ b/osgp-dto/src/main/java/com/alliander/osgp/dto/valueobjects/smartmetering/ActiveEnergyValuesDto.java
@@ -7,7 +7,11 @@
  */
 package com.alliander.osgp.dto.valueobjects.smartmetering;
 
-public class ActiveEnergyValuesDto {
+import java.io.Serializable;
+
+public class ActiveEnergyValuesDto implements Serializable {
+
+    private static final long serialVersionUID = 5775074609152210861L;
 
     private final DlmsMeterValueDto activeEnergyImport;
     private final DlmsMeterValueDto activeEnergyExport;

--- a/osgp-dto/src/main/java/com/alliander/osgp/dto/valueobjects/smartmetering/MeterReadsResponseDto.java
+++ b/osgp-dto/src/main/java/com/alliander/osgp/dto/valueobjects/smartmetering/MeterReadsResponseDto.java
@@ -14,35 +14,11 @@ public class MeterReadsResponseDto extends ActionResponseDto {
 
     private final Date logTime;
 
-    private final DlmsMeterValueDto activeEnergyImport;
-    private final DlmsMeterValueDto activeEnergyExport;
-    private final DlmsMeterValueDto activeEnergyImportTariffOne;
-    // may be null
-    private final DlmsMeterValueDto activeEnergyImportTariffTwo;
-    private final DlmsMeterValueDto activeEnergyExportTariffOne;
-    // may be null
-    private final DlmsMeterValueDto activeEnergyExportTariffTwo;
-
-    public MeterReadsResponseDto(final Date logTime, final DlmsMeterValueDto activeEnergyImport,
-            final DlmsMeterValueDto activeEnergyExport, final DlmsMeterValueDto activeEnergyImportTariffOne,
-            final DlmsMeterValueDto activeEnergyImportTariffTwo, final DlmsMeterValueDto activeEnergyExportTariffOne,
-            final DlmsMeterValueDto activeEnergyExportTariffTwo) {
-
-        this.logTime = new Date(logTime.getTime());
-        this.activeEnergyImportTariffOne = activeEnergyImportTariffOne;
-        this.activeEnergyImportTariffTwo = activeEnergyImportTariffTwo;
-        this.activeEnergyExportTariffOne = activeEnergyExportTariffOne;
-        this.activeEnergyExportTariffTwo = activeEnergyExportTariffTwo;
-        this.activeEnergyImport = activeEnergyImport;
-        this.activeEnergyExport = activeEnergyExport;
-    }
+    private final ActiveEnergyValuesDto activeEnergyValues;
 
     public MeterReadsResponseDto(final Date logTime, final ActiveEnergyValuesDto activeEnergyValues) {
-        this(logTime, activeEnergyValues.getActiveEnergyImport(), activeEnergyValues.getActiveEnergyExport(),
-                activeEnergyValues.getActiveEnergyImportTariffOne(),
-                activeEnergyValues.getActiveEnergyImportTariffTwo(),
-                activeEnergyValues.getActiveEnergyExportTariffOne(),
-                activeEnergyValues.getActiveEnergyExportTariffTwo());
+        this.logTime = new Date(logTime.getTime());
+        this.activeEnergyValues = activeEnergyValues;
     }
 
     public Date getLogTime() {
@@ -50,43 +26,41 @@ public class MeterReadsResponseDto extends ActionResponseDto {
     }
 
     public DlmsMeterValueDto getActiveEnergyImportTariffOne() {
-        return this.activeEnergyImportTariffOne;
+        return this.activeEnergyValues.getActiveEnergyImportTariffOne();
     }
 
     public DlmsMeterValueDto getActiveEnergyImportTariffTwo() {
-        return this.activeEnergyImportTariffTwo;
+        return this.activeEnergyValues.getActiveEnergyImportTariffTwo();
     }
 
     public DlmsMeterValueDto getActiveEnergyExportTariffOne() {
-        return this.activeEnergyExportTariffOne;
+        return this.activeEnergyValues.getActiveEnergyExportTariffOne();
     }
 
     public DlmsMeterValueDto getActiveEnergyExportTariffTwo() {
-        return this.activeEnergyExportTariffTwo;
+        return this.activeEnergyValues.getActiveEnergyExportTariffTwo();
     }
 
     public DlmsMeterValueDto getActiveEnergyImport() {
-        return this.activeEnergyImport;
+        return this.activeEnergyValues.getActiveEnergyImport();
     }
 
     public DlmsMeterValueDto getActiveEnergyExport() {
-        return this.activeEnergyExport;
+        return this.activeEnergyValues.getActiveEnergyExport();
     }
 
     public ActiveEnergyValuesDto getActiveEnergyValues() {
-        return new ActiveEnergyValuesDto(this.activeEnergyImport, this.activeEnergyExport,
-                this.activeEnergyImportTariffOne, this.activeEnergyImportTariffTwo, this.activeEnergyExportTariffOne,
-                this.activeEnergyExportTariffTwo);
+        return this.activeEnergyValues;
     }
 
     @Override
     public String toString() {
-        return "MeterReads [logTime=" + this.logTime + ", activeEnergyImport=" + this.activeEnergyImport
-                + ", activeEnergyExport=" + this.activeEnergyExport + ", activeEnergyImportTariffOne="
-                + this.activeEnergyImportTariffOne + ", activeEnergyImportTariffTwo="
-                + this.activeEnergyImportTariffTwo + ", activeEnergyExportTariffOne="
-                + this.activeEnergyExportTariffOne + ", activeEnergyExportTariffTwo="
-                + this.activeEnergyExportTariffTwo + "]";
+        return "MeterReads[logTime=" + this.logTime + ", " + this.activeEnergyValues + ", activeEnergyExport="
+                + this.getActiveEnergyExport() + ", activeEnergyImportTariffOne="
+                + this.getActiveEnergyImportTariffOne() + ", activeEnergyImportTariffTwo="
+                + this.getActiveEnergyImportTariffTwo() + ", activeEnergyExportTariffOne="
+                + this.getActiveEnergyExportTariffOne() + ", activeEnergyExportTariffTwo="
+                + this.getActiveEnergyExportTariffTwo() + "]";
     }
 
 }

--- a/osgp-dto/src/main/java/com/alliander/osgp/dto/valueobjects/smartmetering/MeterReadsResponseDto.java
+++ b/osgp-dto/src/main/java/com/alliander/osgp/dto/valueobjects/smartmetering/MeterReadsResponseDto.java
@@ -27,7 +27,7 @@ public class MeterReadsResponseDto extends ActionResponseDto {
             final DlmsMeterValueDto activeEnergyExport, final DlmsMeterValueDto activeEnergyImportTariffOne,
             final DlmsMeterValueDto activeEnergyImportTariffTwo, final DlmsMeterValueDto activeEnergyExportTariffOne,
             final DlmsMeterValueDto activeEnergyExportTariffTwo) {
-        super();
+
         this.logTime = new Date(logTime.getTime());
         this.activeEnergyImportTariffOne = activeEnergyImportTariffOne;
         this.activeEnergyImportTariffTwo = activeEnergyImportTariffTwo;
@@ -35,6 +35,14 @@ public class MeterReadsResponseDto extends ActionResponseDto {
         this.activeEnergyExportTariffTwo = activeEnergyExportTariffTwo;
         this.activeEnergyImport = activeEnergyImport;
         this.activeEnergyExport = activeEnergyExport;
+    }
+
+    public MeterReadsResponseDto(final Date logTime, final ActiveEnergyValuesDto activeEnergyValues) {
+        this(logTime, activeEnergyValues.getActiveEnergyImport(), activeEnergyValues.getActiveEnergyExport(),
+                activeEnergyValues.getActiveEnergyImportTariffOne(),
+                activeEnergyValues.getActiveEnergyImportTariffTwo(),
+                activeEnergyValues.getActiveEnergyExportTariffOne(),
+                activeEnergyValues.getActiveEnergyExportTariffTwo());
     }
 
     public Date getLogTime() {
@@ -63,6 +71,12 @@ public class MeterReadsResponseDto extends ActionResponseDto {
 
     public DlmsMeterValueDto getActiveEnergyExport() {
         return this.activeEnergyExport;
+    }
+
+    public ActiveEnergyValuesDto getActiveEnergyValues() {
+        return new ActiveEnergyValuesDto(this.activeEnergyImport, this.activeEnergyExport,
+                this.activeEnergyImportTariffOne, this.activeEnergyImportTariffTwo, this.activeEnergyExportTariffOne,
+                this.activeEnergyExportTariffTwo);
     }
 
     @Override

--- a/osgp-dto/src/main/java/com/alliander/osgp/dto/valueobjects/smartmetering/PeriodicMeterReadsResponseItemDto.java
+++ b/osgp-dto/src/main/java/com/alliander/osgp/dto/valueobjects/smartmetering/PeriodicMeterReadsResponseItemDto.java
@@ -21,27 +21,15 @@ public class PeriodicMeterReadsResponseItemDto extends MeterReadsResponseDto {
      *
      * @param logTime
      *            the time the meter reads are logged on the device
-     * @param activeEnergyImport
-     *            the value of activeEnergyImport
-     * @param activeEnergyExport
-     *            the value of activeEnergyExport
-     * @param activeEnergyImportTariffOne
-     *            the value of activeEnergyImportTariffOne
-     * @param activeEnergyImportTariffTwo
-     *            the value of activeEnergyImportTariffTwo
-     * @param activeEnergyExportTariffOne
-     *            the value of activeEnergyExportTariffOne
-     * @param activeEnergyExportTariffTwo
-     *            the value of activeEnergyExportTariffTwo
+     * @param activeEnergyValues
+     *            the active energy values
      * @param amrProfileStatusCode
      *            the value of amrProfileStatusCode
      */
-    public PeriodicMeterReadsResponseItemDto(final Date logTime, final DlmsMeterValueDto activeEnergyImport,
-            final DlmsMeterValueDto activeEnergyExport, final DlmsMeterValueDto activeEnergyImportTariffOne,
-            final DlmsMeterValueDto activeEnergyImportTariffTwo, final DlmsMeterValueDto activeEnergyExportTariffOne,
-            final DlmsMeterValueDto activeEnergyExportTariffTwo, final AmrProfileStatusCodeDto amrProfileStatusCode) {
-        super(logTime, activeEnergyImport, activeEnergyExport, activeEnergyImportTariffOne, activeEnergyImportTariffTwo,
-                activeEnergyExportTariffOne, activeEnergyExportTariffTwo);
+    public PeriodicMeterReadsResponseItemDto(final Date logTime, final ActiveEnergyValuesDto activeEnergyValues,
+            final AmrProfileStatusCodeDto amrProfileStatusCode) {
+
+        super(logTime, activeEnergyValues);
 
         this.amrProfileStatusCode = amrProfileStatusCode;
     }
@@ -64,8 +52,8 @@ public class PeriodicMeterReadsResponseItemDto extends MeterReadsResponseDto {
             final DlmsMeterValueDto activeEnergyImportTariffTwo, final DlmsMeterValueDto activeEnergyExportTariffOne,
             final DlmsMeterValueDto activeEnergyExportTariffTwo) {
 
-        this(logTime, null, null, activeEnergyImportTariffOne, activeEnergyImportTariffTwo, activeEnergyExportTariffOne,
-                activeEnergyExportTariffTwo, null);
+        this(logTime, new ActiveEnergyValuesDto(null, null, activeEnergyImportTariffOne, activeEnergyImportTariffTwo,
+                activeEnergyExportTariffOne, activeEnergyExportTariffTwo), null);
     }
 
     /**
@@ -87,8 +75,8 @@ public class PeriodicMeterReadsResponseItemDto extends MeterReadsResponseDto {
     public PeriodicMeterReadsResponseItemDto(final Date logTime, final DlmsMeterValueDto activeEnergyImportTariffOne,
             final DlmsMeterValueDto activeEnergyImportTariffTwo, final DlmsMeterValueDto activeEnergyExportTariffOne,
             final DlmsMeterValueDto activeEnergyExportTariffTwo, final AmrProfileStatusCodeDto amrProfileStatusCode) {
-        this(logTime, null, null, activeEnergyImportTariffOne, activeEnergyImportTariffTwo, activeEnergyExportTariffOne,
-                activeEnergyExportTariffTwo, amrProfileStatusCode);
+        this(logTime, new ActiveEnergyValuesDto(null, null, activeEnergyImportTariffOne, activeEnergyImportTariffTwo,
+                activeEnergyExportTariffOne, activeEnergyExportTariffTwo), amrProfileStatusCode);
     }
 
     /**

--- a/osgp-dto/src/main/java/com/alliander/osgp/dto/valueobjects/smartmetering/PeriodicMeterReadsResponseItemDto.java
+++ b/osgp-dto/src/main/java/com/alliander/osgp/dto/valueobjects/smartmetering/PeriodicMeterReadsResponseItemDto.java
@@ -93,7 +93,8 @@ public class PeriodicMeterReadsResponseItemDto extends MeterReadsResponseDto {
      */
     public PeriodicMeterReadsResponseItemDto(final Date logTime, final DlmsMeterValueDto activeEnergyImport,
             final DlmsMeterValueDto activeEnergyExport, final AmrProfileStatusCodeDto amrProfileStatusCode) {
-        super(logTime, activeEnergyImport, activeEnergyExport, null, null, null, null);
+
+        super(logTime, new ActiveEnergyValuesDto(activeEnergyImport, activeEnergyExport, null, null, null, null));
 
         this.amrProfileStatusCode = amrProfileStatusCode;
     }


### PR DESCRIPTION
One of the constructors of PeriodicMeterReadsResponseItemDto is changed
to take a single value object for the active energy reads values so the
number of arguments does not exceed the maximum number allowed.