### PR TITLE
FLEX-4022 ~ Adds notification web service WSDL, XSD and config.

### DIFF
--- a/osgp-ws-core/pom.xml
+++ b/osgp-ws-core/pom.xml
@@ -105,6 +105,23 @@
               <clearOutputDir>false</clearOutputDir>
             </configuration>
           </execution>
+          <execution>
+            <id>notification</id>
+            <goals>
+              <goal>xjc</goal>
+            </goals>
+            <configuration>
+              <bindingDirectory>src/main/resources/schemas</bindingDirectory>
+              <bindingFiles>notification.xjb</bindingFiles>
+              <schemaDirectory>src/main/resources</schemaDirectory>
+              <schemaFiles>Notification.wsdl</schemaFiles>
+              <wsdl>true</wsdl>
+              <xmlschema>false</xmlschema>
+              <staleFile>${project.build.directory}/jaxb2/.schema-notification-stale-flag</staleFile>
+              <!-- USE THIS ONLY FOR THE FIRST EXECUTION -->
+              <clearOutputDir>false</clearOutputDir>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/osgp-ws-core/src/main/java/com/alliander/osgp/ws/core/config/NotificationWebServiceConfig.java
+++ b/osgp-ws-core/src/main/java/com/alliander/osgp/ws/core/config/NotificationWebServiceConfig.java
@@ -1,0 +1,48 @@
+package com.alliander.osgp.ws.core.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.ws.soap.server.endpoint.interceptor.PayloadValidatingInterceptor;
+import org.springframework.ws.wsdl.WsdlDefinition;
+import org.springframework.ws.wsdl.wsdl11.SimpleWsdl11Definition;
+import org.springframework.xml.xsd.SimpleXsdSchema;
+
+@Configuration
+public class NotificationWebServiceConfig {
+
+    private static final String COMMON_XSD_PATH = "schemas/common.xsd";
+
+    private static final String NOTIFICATION_XSD_PATH = "schemas/notification.xsd";
+
+    private static final String NOTIFICATION_WSDL_PATH = "Notification.wsdl";
+
+    @Bean
+    public PayloadValidatingInterceptor payloadValidatingInterceptor() {
+        final PayloadValidatingInterceptor payloadValidatingInterceptor = new PayloadValidatingInterceptor();
+        final Resource[] resources = new Resource[] { new ClassPathResource(COMMON_XSD_PATH),
+                new ClassPathResource(NOTIFICATION_XSD_PATH) };
+        payloadValidatingInterceptor.setSchemas(resources);
+        payloadValidatingInterceptor.setValidateRequest(true);
+        payloadValidatingInterceptor.setValidateResponse(false);
+
+        return payloadValidatingInterceptor;
+    }
+
+    @Bean(name = "common-xsd")
+    public SimpleXsdSchema commonXsd() {
+        return new SimpleXsdSchema(new ClassPathResource(COMMON_XSD_PATH));
+    }
+
+    @Bean(name = "notification-wsdl")
+    public WsdlDefinition motificationWsdl() {
+        return new SimpleWsdl11Definition(new ClassPathResource(NOTIFICATION_WSDL_PATH));
+    }
+
+    @Bean(name = "notification-xsd")
+    public SimpleXsdSchema notificationXsd() {
+        return new SimpleXsdSchema(new ClassPathResource(NOTIFICATION_XSD_PATH));
+    }
+
+}

--- a/osgp-ws-core/src/main/java/com/alliander/osgp/ws/core/config/NotificationWebServiceConfig.java
+++ b/osgp-ws-core/src/main/java/com/alliander/osgp/ws/core/config/NotificationWebServiceConfig.java
@@ -1,3 +1,12 @@
+/**
+ * Copyright 2018 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
 package com.alliander.osgp.ws.core.config;
 
 import org.springframework.context.annotation.Bean;
@@ -35,12 +44,12 @@ public class NotificationWebServiceConfig {
         return new SimpleXsdSchema(new ClassPathResource(COMMON_XSD_PATH));
     }
 
-    @Bean(name = "notification-wsdl")
-    public WsdlDefinition motificationWsdl() {
+    @Bean(name = "Notification")
+    public WsdlDefinition notificationWsdl() {
         return new SimpleWsdl11Definition(new ClassPathResource(NOTIFICATION_WSDL_PATH));
     }
 
-    @Bean(name = "notification-xsd")
+    @Bean(name = "notification")
     public SimpleXsdSchema notificationXsd() {
         return new SimpleXsdSchema(new ClassPathResource(NOTIFICATION_XSD_PATH));
     }

--- a/osgp-ws-core/src/main/resources/Notification.wsdl
+++ b/osgp-ws-core/src/main/resources/Notification.wsdl
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Platform version: ${display.version} -->
+
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+  xmlns:notification="http://www.alliander.com/schemas/osgp/netmanagement/osgp-notification/2018/01"
+  xmlns:common="http://www.alliander.com/schemas/osgp/common/2014/10"
+  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+  xmlns:tns="http://www.alliander.com/definitions/osgp/notification-v1.0"
+  targetNamespace="http://www.alliander.com/definitions/osgp/notification-v1.0">
+
+  <wsdl:types>
+    <xsd:schema
+      targetNamespace="http://www.alliander.com/definitions/osgp/notification/imports"
+      xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+      <xsd:import
+        namespace="http://www.alliander.com/schemas/osgp/netmanagement/osgp-notification/2018/01"
+        schemaLocation="schemas/notification.xsd" />
+    </xsd:schema>
+  </wsdl:types>
+
+  <wsdl:message name="SendNotificationHeader">
+    <wsdl:part element="common:OrganisationIdentification" name="OrganisationIdentification" />
+    <wsdl:part element="common:UserName" name="UserName" />
+    <wsdl:part element="common:ApplicationName" name="ApplicationName" />
+  </wsdl:message>
+  <wsdl:message name="SendNotificationRequest">
+    <wsdl:part element="notification:SendNotificationRequest" name="SendNotificationRequest">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="SendNotificationResponse">
+    <wsdl:part element="notification:SendNotificationResponse" name="SendNotificationResponse">
+    </wsdl:part>
+  </wsdl:message>
+
+  <wsdl:portType name="NotificationPort">
+    <wsdl:operation name="SendNotification">
+      <wsdl:input message="tns:SendNotificationRequest" name="SendNotificationRequest">
+      </wsdl:input>
+      <wsdl:output message="tns:SendNotificationResponse" name="SendNotificationResponse">
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:portType>
+
+  <wsdl:binding name="NotificationPortSoap11"
+    type="tns:NotificationPort">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+    <wsdl:operation name="SendNotification">
+      <soap:operation soapAction="" />
+      <wsdl:input name="SendNotificationRequest">
+        <soap:header message="tns:SendNotificationHeader" part="OrganisationIdentification" use="literal" />
+        <soap:header message="tns:SendNotificationHeader" part="UserName" use="literal" />
+        <soap:header message="tns:SendNotificationHeader" part="ApplicationName" use="literal" />
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output name="SendNotificationResponse">
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+
+  <wsdl:service name="NotificationPortService">
+    <wsdl:port binding="tns:NotificationPortSoap11"
+      name="NotificationPortSoap11">
+      <soap:address
+        location="http://localhost:8080/web-api-net-management/soap/osgp/notificationService/" />
+    </wsdl:port>
+  </wsdl:service>
+
+</wsdl:definitions>

--- a/osgp-ws-core/src/main/resources/Notification.wsdl
+++ b/osgp-ws-core/src/main/resources/Notification.wsdl
@@ -62,7 +62,7 @@
     <wsdl:port binding="tns:NotificationPortSoap11"
       name="NotificationPortSoap11">
       <soap:address
-        location="http://localhost:8080/web-api-net-management/soap/osgp/notificationService/" />
+        location="http://localhost:8080/context/soap/osgp/notificationService/" />
     </wsdl:port>
   </wsdl:service>
 

--- a/osgp-ws-core/src/main/resources/schemas/notification.xjb
+++ b/osgp-ws-core/src/main/resources/schemas/notification.xjb
@@ -1,6 +1,12 @@
-<!-- Copyright 2018 Smart Society Services B.V. Licensed under the Apache 
-  License, Version 2.0 (the "License"); you may not use this file except in 
-  compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 -->
+<!--
+  Copyright 2018 Smart Society Services B.V.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+-->
 <jxb:bindings version="2.0" xmlns:jxb="http://java.sun.com/xml/ns/jaxb"
   xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
@@ -10,17 +16,6 @@
         name="com.alliander.osgp.adapter.ws.schema.core.common"></jxb:package>
     </jxb:schemaBindings>
   </jxb:bindings>
-  
-<!--   <jxb:bindings schemaLocation="devicemanagement.xsd">
-    <jxb:schemaBindings>
-      <jxb:package
-        name="com.alliander.osgp.adapter.ws.schema.core.devicemanagement"></jxb:package>
-    </jxb:schemaBindings>
-    
-    <jxb:bindings node="//xs:complexType[@name='RelayStatuses']//xs:element[@name='RelayStatus']">
-      <jxb:property name="RelayStatuses" />
-    </jxb:bindings>
-  </jxb:bindings> -->
 
   <jxb:bindings schemaLocation="notification.xsd">
     <jxb:schemaBindings>

--- a/osgp-ws-core/src/main/resources/schemas/notification.xjb
+++ b/osgp-ws-core/src/main/resources/schemas/notification.xjb
@@ -1,0 +1,32 @@
+<!-- Copyright 2018 Smart Society Services B.V. Licensed under the Apache 
+  License, Version 2.0 (the "License"); you may not use this file except in 
+  compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 -->
+<jxb:bindings version="2.0" xmlns:jxb="http://java.sun.com/xml/ns/jaxb"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <jxb:bindings schemaLocation="common.xsd">
+    <jxb:schemaBindings>
+      <jxb:package
+        name="com.alliander.osgp.adapter.ws.schema.core.common"></jxb:package>
+    </jxb:schemaBindings>
+  </jxb:bindings>
+  
+<!--   <jxb:bindings schemaLocation="devicemanagement.xsd">
+    <jxb:schemaBindings>
+      <jxb:package
+        name="com.alliander.osgp.adapter.ws.schema.core.devicemanagement"></jxb:package>
+    </jxb:schemaBindings>
+    
+    <jxb:bindings node="//xs:complexType[@name='RelayStatuses']//xs:element[@name='RelayStatus']">
+      <jxb:property name="RelayStatuses" />
+    </jxb:bindings>
+  </jxb:bindings> -->
+
+  <jxb:bindings schemaLocation="notification.xsd">
+    <jxb:schemaBindings>
+      <jxb:package
+        name="com.alliander.osgp.adapter.ws.schema.core.notification"></jxb:package>
+    </jxb:schemaBindings>
+  </jxb:bindings>
+
+</jxb:bindings>

--- a/osgp-ws-core/src/main/resources/schemas/notification.xsd
+++ b/osgp-ws-core/src/main/resources/schemas/notification.xsd
@@ -1,0 +1,43 @@
+<!-- Copyright 2018 Smart Society Services B.V. Licensed under the Apache 
+  License, Version 2.0 (the "License"); you may not use this file except in 
+  compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 -->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns:tns="http://www.alliander.com/schemas/osgp/netmanagement/osgp-notification/2018/01"
+  xmlns:common="http://www.alliander.com/schemas/osgp/common/2014/10"
+  attributeFormDefault="unqualified" elementFormDefault="qualified"
+  targetNamespace="http://www.alliander.com/schemas/osgp/netmanagement/osgp-notification/2018/01">
+
+  <xsd:import namespace="http://www.alliander.com/schemas/osgp/common/2014/10"
+    schemaLocation="common.xsd" />
+  <xsd:import namespace="http://www.alliander.com/schemas/osgp/devicemanagement/2014/10"
+    schemaLocation="devicemanagement.xsd" />
+
+  <xsd:element name="SendNotificationRequest">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="Notification" type="tns:Notification" />
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="SendNotificationResponse">
+    <xsd:complexType />
+  </xsd:element>
+
+  <xsd:complexType name="Notification">
+    <xsd:sequence>
+      <xsd:element name="Message" type="xsd:string" minOccurs="0" maxOccurs="1" />
+      <xsd:element name="Result" type="xsd:string" minOccurs="0" maxOccurs="1" />
+      <xsd:element name="DeviceIdentification" type="xsd:string" minOccurs="1" maxOccurs="1" />
+      <xsd:element name="CorrelationUid" type="common:CorrelationUid" minOccurs="0" maxOccurs="1" />
+      <xsd:element name="NotificationType" type="tns:NotificationType" minOccurs="1" maxOccurs="1" />
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:simpleType name="NotificationType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="DEVICE_UPDATED" />
+    </xsd:restriction>
+  </xsd:simpleType>
+
+</xsd:schema>

--- a/osgp-ws-core/src/main/resources/schemas/notification.xsd
+++ b/osgp-ws-core/src/main/resources/schemas/notification.xsd
@@ -1,6 +1,12 @@
-<!-- Copyright 2018 Smart Society Services B.V. Licensed under the Apache 
-  License, Version 2.0 (the "License"); you may not use this file except in 
-  compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 -->
+<!--
+  Copyright 2018 Smart Society Services B.V.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+-->
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
   xmlns:tns="http://www.alliander.com/schemas/osgp/netmanagement/osgp-notification/2018/01"
   xmlns:common="http://www.alliander.com/schemas/osgp/common/2014/10"
@@ -9,8 +15,6 @@
 
   <xsd:import namespace="http://www.alliander.com/schemas/osgp/common/2014/10"
     schemaLocation="common.xsd" />
-  <xsd:import namespace="http://www.alliander.com/schemas/osgp/devicemanagement/2014/10"
-    schemaLocation="devicemanagement.xsd" />
 
   <xsd:element name="SendNotificationRequest">
     <xsd:complexType>
@@ -26,16 +30,17 @@
 
   <xsd:complexType name="Notification">
     <xsd:sequence>
-      <xsd:element name="Message" type="xsd:string" minOccurs="0" maxOccurs="1" />
-      <xsd:element name="Result" type="xsd:string" minOccurs="0" maxOccurs="1" />
-      <xsd:element name="DeviceIdentification" type="xsd:string" minOccurs="1" maxOccurs="1" />
-      <xsd:element name="CorrelationUid" type="common:CorrelationUid" minOccurs="0" maxOccurs="1" />
-      <xsd:element name="NotificationType" type="tns:NotificationType" minOccurs="1" maxOccurs="1" />
+      <xsd:element name="CorrelationUid" type="common:CorrelationUid" minOccurs="0" />
+      <xsd:element name="DeviceIdentification" type="common:Identification" />
+      <xsd:element name="Message" type="xsd:string" minOccurs="0" />
+      <xsd:element name="NotificationType" type="tns:NotificationType" />
+      <xsd:element name="Result" type="common:OsgpResultType" minOccurs="0" />
     </xsd:sequence>
   </xsd:complexType>
 
   <xsd:simpleType name="NotificationType">
     <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="DEVICE_AUTHORIZATION_UPDATED" />
       <xsd:enumeration value="DEVICE_UPDATED" />
     </xsd:restriction>
   </xsd:simpleType>

--- a/shared/src/main/java/com/alliander/osgp/shared/application/config/AbstractWsAdapterInitializer.java
+++ b/shared/src/main/java/com/alliander/osgp/shared/application/config/AbstractWsAdapterInitializer.java
@@ -42,9 +42,9 @@ public abstract class AbstractWsAdapterInitializer extends AbstractApplicationIn
      * DispatchServlet
      *
      * @param servletContext
-     *            Java servlet context as supplied by application server
+     *            Java servlet context as supplied by application server.
      * @throws ServletException
-     *             thrown when a servlet encounters difficulty
+     *             Thrown when a servlet encounters difficulty.
      */
     @Override
     protected void startUp(final ServletContext servletContext) throws ServletException {
@@ -57,5 +57,35 @@ public abstract class AbstractWsAdapterInitializer extends AbstractApplicationIn
         final ServletRegistration.Dynamic dispatcher = servletContext.addServlet(DISPATCHER_SERVLET_NAME, servlet);
         dispatcher.setLoadOnStartup(1);
         dispatcher.addMapping(DISPATCHER_SERVLET_MAPPING);
+    }
+
+    /**
+     * Custom startup of application context for webservice adapters which can
+     * be used to initialize the servlet on a different mapping using a
+     * different name.
+     *
+     * @param servletContext
+     *            Java servlet context as supplied by application server.
+     * @param servletName
+     *            The custom servlet name to be used instead of
+     *            {@code DISPATCHER_SERVLET_NAME}.
+     * @param servletMapping
+     *            The custom servlet mapping to be used instead of
+     *            {@code DISPATCHER_SERVLET_MAPPING}.
+     *
+     * @throws ServletException
+     *             Thrown when a servlet encounters difficulty.
+     */
+    protected void customStartUp(final ServletContext servletContext, final String servletName,
+            final String servletMapping) throws ServletException {
+        super.startUp(servletContext);
+
+        final MessageDispatcherServlet servlet = new MessageDispatcherServlet();
+        servlet.setContextClass(AnnotationConfigWebApplicationContext.class);
+        servlet.setTransformWsdlLocations(true);
+
+        final ServletRegistration.Dynamic dispatcher = servletContext.addServlet(servletName, servlet);
+        dispatcher.setLoadOnStartup(1);
+        dispatcher.addMapping(servletMapping);
     }
 }

--- a/shared/src/main/java/com/alliander/osgp/shared/application/config/jms/JmsConfigurationNames.java
+++ b/shared/src/main/java/com/alliander/osgp/shared/application/config/jms/JmsConfigurationNames.java
@@ -28,6 +28,8 @@ public class JmsConfigurationNames {
 
     public static final String JMS_COMMON_WS_RESPONSES = "jms.common.ws.responses";
 
+    public static final String JMS_COMMON_DOMAIN_TO_WS_REQUESTS = "jms.common.domain.to.ws.requests";
+
     public static final String JMS_OSGP_CORE_REQUESTS = "jms.osgp.core.requests";
 
     public static final String JMS_OSGP_CORE_RESPONSES = "jms.osgp.core.responses";


### PR DESCRIPTION
- adds WSDL, XSD and configuration class for notification service
- adds `customStartUp()` to `AbstractWsAdapterInitializer` to be able to create a web service using a different URL mapping and name
- adds `isSecurityEnabled` to `DefaultWebServiceTemplateFactory` to be able to create a SOAP client without using client certificate and Java Key Store
- adds a name to `JmsConfigurationNames` for JMS properties for a queue from osgp-adapter-domain-core to osgp-adapter-ws-core to be able to send a queue message to osgp-adapter-ws-core when a device sends events which change the relay status for the device to OSGP
