### PR TITLE
SLIM-1626 Make GprsOperationMode and ConfigurationFlags optional for SetConfigurationObject SLIM-1060

### DIFF
--- a/osgp-dto/src/main/java/com/alliander/osgp/dto/valueobjects/smartmetering/ConfigurationFlagDto.java
+++ b/osgp-dto/src/main/java/com/alliander/osgp/dto/valueobjects/smartmetering/ConfigurationFlagDto.java
@@ -24,6 +24,11 @@ public class ConfigurationFlagDto implements Serializable {
         this.enabled = enabled;
     }
 
+    @Override
+    public String toString() {
+        return String.format("Flag[%s %s]", this.configurationFlagType, this.enabled ? "enabled" : "disabled");
+    }
+
     public ConfigurationFlagTypeDto getConfigurationFlagType() {
         return this.configurationFlagType;
     }

--- a/osgp-dto/src/main/java/com/alliander/osgp/dto/valueobjects/smartmetering/ConfigurationFlagsDto.java
+++ b/osgp-dto/src/main/java/com/alliander/osgp/dto/valueobjects/smartmetering/ConfigurationFlagsDto.java
@@ -23,6 +23,11 @@ public class ConfigurationFlagsDto implements Serializable {
         this.configurationFlag = new ArrayList<>(configurationFlag);
     }
 
+    @Override
+    public String toString() {
+        return this.configurationFlag == null ? "Flags[none]" : String.format("Flags%s", this.configurationFlag);
+    }
+
     public List<ConfigurationFlagDto> getConfigurationFlag() {
         return new ArrayList<>(this.configurationFlag);
     }

--- a/osgp-dto/src/main/java/com/alliander/osgp/dto/valueobjects/smartmetering/ConfigurationObjectDto.java
+++ b/osgp-dto/src/main/java/com/alliander/osgp/dto/valueobjects/smartmetering/ConfigurationObjectDto.java
@@ -25,6 +25,12 @@ public class ConfigurationObjectDto implements Serializable {
         this.configurationFlags = configurationFlags;
     }
 
+    @Override
+    public String toString() {
+        return String.format("ConfigurationObjectDto[gprsOperationMode=%s, flags=%s]", this.gprsOperationMode,
+                this.configurationFlags);
+    }
+
     public GprsOperationModeTypeDto getGprsOperationMode() {
         return this.gprsOperationMode;
     }

--- a/osgp-ws-smartmetering/src/main/resources/schemas/sm-configuration.xsd
+++ b/osgp-ws-smartmetering/src/main/resources/schemas/sm-configuration.xsd
@@ -893,8 +893,8 @@
 
   <xsd:complexType name="ConfigurationObject">
     <xsd:sequence>
-      <xsd:element name="GprsOperationMode" type="tns:GprsOperationModeType" />
-      <xsd:element name="ConfigurationFlags" type="tns:ConfigurationFlags" />
+      <xsd:element name="GprsOperationMode" type="tns:GprsOperationModeType" minOccurs="0" maxOccurs="1" />
+      <xsd:element name="ConfigurationFlags" type="tns:ConfigurationFlags" minOccurs="0" maxOccurs="1" />
     </xsd:sequence>
   </xsd:complexType>
 


### PR DESCRIPTION
The GprsOperationMode and ConfigurationFlags are both made optional
parts of the ConfigurationObject so they don't need to be provided both
when a SetConfigurationObjectRequest is prepared.

Adds toString to ConfigurationObject related DTOs to enable easier
debugging and simpler logging statements.