### PR TITLE
SLIM-1662 Replaces Quartz C3P0 pool by HikariCP

### DIFF
--- a/parent-shared/pom.xml
+++ b/parent-shared/pom.xml
@@ -75,7 +75,7 @@
     <apache.commons.schema>2.0.3</apache.commons.schema>
     <maven.compiler.plugin.version>3.6.0</maven.compiler.plugin.version>
     <license.maven.plugin>2.11</license.maven.plugin>
-    <quartz.version>2.2.3</quartz.version>
+    <quartz.version>2.3.0</quartz.version>
     <hikaricp.version>2.6.0</hikaricp.version>
   </properties>
 

--- a/shared/src/main/java/com/alliander/osgp/shared/application/config/AbstractSchedulingConfig.java
+++ b/shared/src/main/java/com/alliander/osgp/shared/application/config/AbstractSchedulingConfig.java
@@ -71,13 +71,11 @@ public abstract class AbstractSchedulingConfig extends AbstractConfig {
         return scheduler;
     }
 
-    private Properties constructQuartzConfiguration(
-            final SchedulingConfigProperties schedulingConfigProperties) {
+    private Properties constructQuartzConfiguration(final SchedulingConfigProperties schedulingConfigProperties) {
         final Properties properties = new Properties();
 
         // Default Properties
-        properties.put("org.quartz.scheduler.instanceName",
-                schedulingConfigProperties.getJobClass().getSimpleName());
+        properties.put("org.quartz.scheduler.instanceName", schedulingConfigProperties.getJobClass().getSimpleName());
         properties.put("org.quartz.scheduler.instanceId", "AUTO");
         properties.put("org.quartz.scheduler.rmi.export", Boolean.FALSE.toString());
         properties.put("org.quartz.scheduler.rmi.proxy", Boolean.FALSE.toString());
@@ -106,15 +104,12 @@ public abstract class AbstractSchedulingConfig extends AbstractConfig {
         properties.put("org.quartz.jobStore.misfireThreshold", "60000");
         properties.put("org.quartz.jobStore.dataSource", "quartzDefault");
 
-        // DataSource configuration using Quartz implementation. HikariCP does
-        // not work property (TX and auto commit).
-        properties.put("org.quartz.dataSource.quartzDefault.driver",
-                schedulingConfigProperties.getJobStoreDbDriver());
+        properties.put("org.quartz.dataSource.quartzDefault.driver", schedulingConfigProperties.getJobStoreDbDriver());
         properties.put("org.quartz.dataSource.quartzDefault.URL", schedulingConfigProperties.getJobStoreDbUrl());
-        properties.put("org.quartz.dataSource.quartzDefault.user",
-                schedulingConfigProperties.getJobStoreDbUsername());
+        properties.put("org.quartz.dataSource.quartzDefault.user", schedulingConfigProperties.getJobStoreDbUsername());
         properties.put("org.quartz.dataSource.quartzDefault.password",
                 schedulingConfigProperties.getJobStoreDbPassword());
+        properties.put("org.quartz.dataSource.quartzDefault.provider", "hikaricp");
 
         return properties;
     }


### PR DESCRIPTION
Adds property to Quartz configuration indicating the provider for the
data source should be "hikaricp".
Removes comment about HikariCP not working properly with TX and auto
commit (this should be kept in mind when testing to confirm there are
indeed no longer issue of the sort mentioned).

Bumps the Quartz version from 2.2.3 to 2.3.0 since the latter has a util
class HikariCpPoolingConnectionProvider for HikariCP connection pooling.