### PR TITLE
FLEX-4196 ~ Fixes device model deletion.

### DIFF
--- a/osgp-ws-core/src/main/resources/schemas/firmwaremanagement.xsd
+++ b/osgp-ws-core/src/main/resources/schemas/firmwaremanagement.xsd
@@ -232,7 +232,7 @@
           maxOccurs="1">
           <xsd:simpleType>
             <xsd:restriction base="xsd:string">
-              <xsd:maxLength value="15" />
+              <xsd:maxLength value="255" />
             </xsd:restriction>
           </xsd:simpleType>
         </xsd:element>


### PR DESCRIPTION
- limit Model ID to 255 characters in web service, which is equal to the
database column
- limit Model Description to 255 characters in web service, which is
equal to the database column