### PR TITLE
SLIM-1775 Updates schemas and DTOs for Short IDs on scan M-Bus channels

### DIFF
--- a/osgp-dto/src/main/java/com/alliander/osgp/dto/valueobjects/smartmetering/MbusChannelShortEquipmentIdentifierDto.java
+++ b/osgp-dto/src/main/java/com/alliander/osgp/dto/valueobjects/smartmetering/MbusChannelShortEquipmentIdentifierDto.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2018 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.alliander.osgp.dto.valueobjects.smartmetering;
+
+import java.io.Serializable;
+
+public class MbusChannelShortEquipmentIdentifierDto implements Serializable {
+
+    private static final long serialVersionUID = -5219063019275081622L;
+
+    private final short channel;
+    private final MbusShortEquipmentIdentifierDto shortId;
+
+    public MbusChannelShortEquipmentIdentifierDto(final short channel, final MbusShortEquipmentIdentifierDto shortId) {
+        this.channel = channel;
+        this.shortId = shortId;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("MbusChannelShortEquipmentIdentifierDto[channel=%d, shortId=%s]", this.channel,
+                this.shortId);
+    }
+
+    public short getChannel() {
+        return this.channel;
+    }
+
+    public MbusShortEquipmentIdentifierDto getShortId() {
+        return this.shortId;
+    }
+
+}

--- a/osgp-dto/src/main/java/com/alliander/osgp/dto/valueobjects/smartmetering/MbusShortEquipmentIdentifierDto.java
+++ b/osgp-dto/src/main/java/com/alliander/osgp/dto/valueobjects/smartmetering/MbusShortEquipmentIdentifierDto.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2018 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.alliander.osgp.dto.valueobjects.smartmetering;
+
+import java.io.Serializable;
+
+public class MbusShortEquipmentIdentifierDto implements Serializable {
+
+    private static final long serialVersionUID = 6292753531006326645L;
+
+    private final String identificationNumber;
+    private final String manufacturerIdentification;
+    private final Short versionIdentification;
+    private final Short deviceTypeIdentification;
+
+    public MbusShortEquipmentIdentifierDto(final String identificationNumber, final String manufacturerIdentification,
+            final Short versionIdentification, final Short deviceTypeIdentification) {
+
+        this.identificationNumber = identificationNumber;
+        this.manufacturerIdentification = manufacturerIdentification;
+        this.versionIdentification = versionIdentification;
+        this.deviceTypeIdentification = deviceTypeIdentification;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "MbusShortEquipmentIdentifierDto[identificationNumber=%s, manufacturer=%s, version=%d, deviceType=%d]",
+                this.identificationNumber, this.manufacturerIdentification, this.versionIdentification,
+                this.deviceTypeIdentification);
+    }
+
+    public String getIdentificationNumber() {
+        return this.identificationNumber;
+    }
+
+    public String getManufacturerIdentification() {
+        return this.manufacturerIdentification;
+    }
+
+    public Short getVersionIdentification() {
+        return this.versionIdentification;
+    }
+
+    public Short getDeviceTypeIdentification() {
+        return this.deviceTypeIdentification;
+    }
+
+}

--- a/osgp-dto/src/main/java/com/alliander/osgp/dto/valueobjects/smartmetering/ScanMbusChannelsResponseDto.java
+++ b/osgp-dto/src/main/java/com/alliander/osgp/dto/valueobjects/smartmetering/ScanMbusChannelsResponseDto.java
@@ -1,43 +1,34 @@
 /**
  * Copyright 2018 Smart Society Services B.V.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 package com.alliander.osgp.dto.valueobjects.smartmetering;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class ScanMbusChannelsResponseDto extends ActionResponseDto {
 
-    private static final long serialVersionUID = -880241546092002960L;
+    private static final long serialVersionUID = 778017393218321982L;
 
-    private String mbusIdentificationNumber1;
-    private String mbusIdentificationNumber2;
-    private String mbusIdentificationNumber3;
-    private String mbusIdentificationNumber4;
+    private final ArrayList<MbusChannelShortEquipmentIdentifierDto> channelShortIds = new ArrayList<>();
 
-    public ScanMbusChannelsResponseDto(final String mbusIdentificationNumber1, final String mbusIdentificationNumber2,
-            final String mbusIdentificationNumber3, final String mbusIdentificationNumber4) {
-        this.mbusIdentificationNumber1 = mbusIdentificationNumber1;
-        this.mbusIdentificationNumber2 = mbusIdentificationNumber2;
-        this.mbusIdentificationNumber3 = mbusIdentificationNumber3;
-        this.mbusIdentificationNumber4 = mbusIdentificationNumber4;
+    public ScanMbusChannelsResponseDto(final List<MbusChannelShortEquipmentIdentifierDto> channelShortIds) {
+        if (channelShortIds != null) {
+            this.channelShortIds.addAll(channelShortIds);
+        }
     }
 
-    public String getMbusIdentificationNumber1() {
-        return this.mbusIdentificationNumber1;
+    @Override
+    public String toString() {
+        return String.format("ScanMbusChannelsResponseDto[channelShortIds=%s]", this.channelShortIds);
     }
 
-    public String getMbusIdentificationNumber2() {
-        return this.mbusIdentificationNumber2;
+    public List<MbusChannelShortEquipmentIdentifierDto> getChannelShortIds() {
+        return new ArrayList<>(this.channelShortIds);
     }
 
-    public String getMbusIdentificationNumber3() {
-        return this.mbusIdentificationNumber3;
-    }
-
-    public String getMbusIdentificationNumber4() {
-        return this.mbusIdentificationNumber4;
-    }
 }

--- a/osgp-ws-smartmetering/src/main/resources/schemas/common.xsd
+++ b/osgp-ws-smartmetering/src/main/resources/schemas/common.xsd
@@ -732,7 +732,7 @@
       <xsd:element name="LongValue" type="xsd:long" />
     </xsd:choice>
   </xsd:complexType>
-  
+
   <xsd:simpleType name="DeviceLifecycleStatus">
     <xsd:restriction base="xsd:string">
       <xsd:enumeration value="NEW_IN_INVENTORY" />
@@ -751,5 +751,34 @@
       <xsd:maxInclusive value="4" />
     </xsd:restriction>
   </xsd:simpleType>
-  
+
+  <xsd:complexType name="MbusShortEquipmentIdentifier">
+    <xsd:sequence>
+      <xsd:element name="IdentificationNumber" type="tns:MbusIdentificationNumber" nillable="true" />
+      <xsd:element name="ManufacturerIdentification" type="tns:MbusManufacturerIdentification" nillable="true" />
+      <xsd:element name="VersionIdentification" type="tns:MbusVersionIdentification" nillable="true" />
+      <xsd:element name="DeviceTypeIdentification" type="tns:MbusDeviceTypeIdentification" nillable="true" />
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:simpleType name="MbusIdentificationNumber">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="[0-9]{8}"></xsd:pattern>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="MbusManufacturerIdentification">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="[A-Z]{3}"></xsd:pattern>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="MbusVersionIdentification">
+    <xsd:restriction base="xsd:unsignedByte" />
+  </xsd:simpleType>
+
+  <xsd:simpleType name="MbusDeviceTypeIdentification">
+    <xsd:restriction base="xsd:unsignedByte" />
+  </xsd:simpleType>
+
 </xsd:schema>

--- a/osgp-ws-smartmetering/src/main/resources/schemas/sm-adhoc.xjb
+++ b/osgp-ws-smartmetering/src/main/resources/schemas/sm-adhoc.xjb
@@ -16,7 +16,7 @@
     
     <jxb:bindings node="//xs:complexType[@name='ProfileEntries']//xs:element[@name='ProfileEntry']">
       <jxb:property name="profileEntries" />
-    </jxb:bindings>    
+    </jxb:bindings>
   </jxb:bindings>
 
   <jxb:bindings schemaLocation="sm-adhoc.xsd">
@@ -24,6 +24,13 @@
       <jxb:package
         name="com.alliander.osgp.adapter.ws.schema.smartmetering.adhoc"></jxb:package>
     </jxb:schemaBindings>
+
+    <jxb:bindings node="//xs:element[@name='ScanMbusChannelsResponse']//xs:element[@name='ChannelShortId']">
+      <jxb:property name="channelShortIds" />
+    </jxb:bindings>
+    <jxb:bindings node="//xs:complexType[@name='ScanMbusChannelsResponseData']//xs:element[@name='ChannelShortId']">
+      <jxb:property name="channelShortIds" />
+    </jxb:bindings>
   </jxb:bindings>
 
 </jxb:bindings>

--- a/osgp-ws-smartmetering/src/main/resources/schemas/sm-adhoc.xsd
+++ b/osgp-ws-smartmetering/src/main/resources/schemas/sm-adhoc.xsd
@@ -235,12 +235,14 @@
       <xsd:sequence>
         <xsd:element name="Result" type="common:OsgpResultType"
           minOccurs="1" />
-        <xsd:element name="MbusIdentificationNumber1" type="xsd:string" />
-        <xsd:element name="MbusIdentificationNumber2" type="xsd:string" />
-        <xsd:element name="MbusIdentificationNumber3" type="xsd:string" />
-        <xsd:element name="MbusIdentificationNumber4" type="xsd:string" />
+        <xsd:element name="ChannelShortId" type="tns:MbusChannelShortEquipmentIdentifier"
+          minOccurs="0" maxOccurs="4" />
       </xsd:sequence>
     </xsd:complexType>
+    <xsd:unique name="UniqueScanMbusChannelValues">
+      <xsd:selector xpath="tns:ChannelShortId" />
+      <xsd:field xpath="tns:Channel" />
+    </xsd:unique>
   </xsd:element>
   <xsd:complexType name="ScanMbusChannelsRequestData">
     <xsd:complexContent>
@@ -248,21 +250,25 @@
         <xsd:sequence>
         </xsd:sequence>
       </xsd:extension>
-    </xsd:complexContent> 
+    </xsd:complexContent>
   </xsd:complexType>
   <xsd:complexType name="ScanMbusChannelsResponseData">
     <xsd:complexContent>
       <xsd:extension base="common:Response">
         <xsd:sequence>
-          <xsd:element name="MbusIdentificationNumber1" type="xsd:string" />
-          <xsd:element name="MbusIdentificationNumber2" type="xsd:string" />
-          <xsd:element name="MbusIdentificationNumber3" type="xsd:string" />
-          <xsd:element name="MbusIdentificationNumber4" type="xsd:string" />
+          <xsd:element name="ChannelShortId" type="tns:MbusChannelShortEquipmentIdentifier"
+            minOccurs="0" maxOccurs="4" />
         </xsd:sequence>
       </xsd:extension>
     </xsd:complexContent>
   </xsd:complexType>
-  
+  <xsd:complexType name="MbusChannelShortEquipmentIdentifier">
+    <xsd:sequence>
+      <xsd:element name="Channel" type="common:Channel" />
+      <xsd:element name="ShortId" type="common:MbusShortEquipmentIdentifier" nillable="true" />
+    </xsd:sequence>
+  </xsd:complexType>
+
   <xsd:complexType name="AssociationLnListType">
     <xsd:sequence>
       <xsd:element name="AssociationLnListElement" type="tns:AssociationLnListElement"

--- a/osgp-ws-smartmetering/src/main/resources/schemas/sm-bundle.xsd
+++ b/osgp-ws-smartmetering/src/main/resources/schemas/sm-bundle.xsd
@@ -489,6 +489,10 @@
           base="adhoc:ScanMbusChannelsResponseData"></xsd:extension>
       </xsd:complexContent>
     </xsd:complexType>
+    <xsd:unique name="UniqueBundledScanMbusChannelValues">
+      <xsd:selector xpath="adhoc:ChannelShortId" />
+      <xsd:field xpath="adhoc:Channel" />
+    </xsd:unique>
   </xsd:element>
   
   <xsd:complexType name="AllResponses">


### PR DESCRIPTION
On Scan M-Bus Channels all attributes identifying the M-Bus device per
channel should be returned. These are represented conform the M-Bus
Short Equipment Identifier (Short ID) attributes (Identification number,
Manufacturer identification, Version identification, Device type
identification).

* Adds MbusShortEquipmentIdentifierDto as DTO for the M-Bus Short ID.
* Adds MbusChannelShortEquipmentIdentifierDto as DTO for the M-Bus
  Short ID on a particular channel.
* Updates ScanMbusChannelsResponseDto to have a list of M-Bus Short IDs
  per channel instead of four M-Bus identification numbers.
* Adds M-Bus Short ID element related types to common.xsd.
* Replaces four M-Bus identification numbers in the Scan M-Bus Channel
  Response types by a sequence of up to four ChannelShortId elements,
  with at most one ChannelShortId per specific channel in sm-adhoc.xsd.
* Enforces unique channels in ChannelShortId values in bundled response
  in sm-bundle.xsd.