### PR TITLE
Oc 441 remove duplicates infra jms

### DIFF
--- a/osgp-dto/src/main/java/org/opensmartgridplatform/dto/valueobjects/DeviceFunctionDto.java
+++ b/osgp-dto/src/main/java/org/opensmartgridplatform/dto/valueobjects/DeviceFunctionDto.java
@@ -7,6 +7,10 @@
  */
 package org.opensmartgridplatform.dto.valueobjects;
 
+/**
+ * @deprecated Use org.opensmartgridplatform.shared.infra.jms.MessageType instead.
+ */
+@Deprecated
 public enum DeviceFunctionDto {
     START_SELF_TEST,
     STOP_SELF_TEST,
@@ -89,5 +93,5 @@ public enum DeviceFunctionDto {
     CLEAR_ALARM_REGISTER,
     GET_MBUS_ENCRYPTION_KEY_STATUS_BY_CHANNEL,
     SCAN_MBUS_CHANNELS,
-    UPDATE_DEVICE_CDMA_SETTINGS;
+    UPDATE_DEVICE_CDMA_SETTINGS
 }

--- a/shared/src/main/java/org/opensmartgridplatform/shared/infra/jms/BaseMessageProcessor.java
+++ b/shared/src/main/java/org/opensmartgridplatform/shared/infra/jms/BaseMessageProcessor.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright 2015 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.shared.infra.jms;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.opensmartgridplatform.shared.exceptionhandling.ComponentType;
+import org.opensmartgridplatform.shared.exceptionhandling.OsgpException;
+import org.opensmartgridplatform.shared.exceptionhandling.TechnicalException;
+
+/**
+ * Base class for MessageProcessor implementations. Each MessageProcessor
+ * implementation should be annotated with @Component. Further the MessageType
+ * the MessageProcessor implementation can process should be passed in at
+ * construction. The Singleton instance is added to the HashMap of
+ * MessageProcessors after dependency injection has completed.
+ */
+public abstract class BaseMessageProcessor implements MessageProcessor {
+
+    /**
+     * Logger for this class.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(BaseMessageProcessor.class);
+
+    /**
+     * This is the message sender needed for the message processor
+     * implementation to forward response messages to web service adapter.
+     */
+    protected final ResponseMessageSender responseMessageSender;
+
+    /**
+     * The map of message processor instances.
+     */
+    protected final MessageProcessorMap messageProcessorMap;
+    private final ComponentType componentType;
+
+    /**
+     * The message types that a message processor implementation can handle.
+     */
+    protected final List<MessageType> messageTypes = new ArrayList<>();
+
+    /**
+     * Construct a message processor instance by passing in the message type.
+     *
+     * @param messageType
+     *            The message type a message processor can handle.
+     */
+    protected BaseMessageProcessor(final ResponseMessageSender responseMessageSender,
+            final MessageProcessorMap messageProcessorMap,
+            final MessageType messageType,
+            final ComponentType componentType) {
+        this.responseMessageSender = responseMessageSender;
+        this.messageProcessorMap = messageProcessorMap;
+        this.messageTypes.add(messageType);
+        this.componentType = componentType;
+    }
+
+    /**
+     * In case a message processor instance can process multiple message types,
+     * a message type can be added.
+     *
+     * @param messageType
+     *            The message type a message processor can handle.
+     */
+    protected void addMessageType(final MessageType messageType) {
+        this.messageTypes.add(messageType);
+    }
+
+    /**
+     * Initialization function executed after dependency injection has finished.
+     * The MessageProcessor Singleton is added to the HashMap of
+     * MessageProcessors.
+     */
+    @PostConstruct
+    public void init() {
+        for (final MessageType messageType : this.messageTypes) {
+            this.messageProcessorMap.addMessageProcessor(messageType, this);
+        }
+    }
+
+    /**
+     * In case of an error, this function can be used to send a response containing
+     * the exception to the web-service-adapter.
+     *
+     *  @param e
+     *            The exception.
+     * @param correlationUid
+     *            The correlation UID.
+     * @param organisationIdentification
+     *            The organisation identification.
+     * @param deviceIdentification
+     *            The device identification.
+     * @param messageType
+     *            The message type.
+     * @param messagePriority
+     *            The priority of the message.
+     */
+    protected void handleError(final Exception e, final String correlationUid, final String organisationIdentification,
+            final String deviceIdentification, final String messageType, final int messagePriority) {
+        LOGGER.info("handeling error: {} for message type: {}", e.getMessage(), messageType);
+        OsgpException osgpException = null;
+        if (e instanceof OsgpException) {
+            osgpException = (OsgpException) e;
+        } else {
+            osgpException = new TechnicalException(componentType, "An unknown error occurred", e);
+        }
+
+        final ResponseMessage responseMessage = ResponseMessage.newResponseMessageBuilder()
+                .withCorrelationUid(correlationUid).withOrganisationIdentification(organisationIdentification)
+                .withDeviceIdentification(deviceIdentification).withResult(ResponseMessageResultType.NOT_OK)
+                .withOsgpException(osgpException).withDataObject(e).withMessagePriority(messagePriority).build();
+        this.responseMessageSender.send(responseMessage);
+    }
+}

--- a/shared/src/main/java/org/opensmartgridplatform/shared/infra/jms/BaseMessageProcessor.java
+++ b/shared/src/main/java/org/opensmartgridplatform/shared/infra/jms/BaseMessageProcessor.java
@@ -57,8 +57,7 @@ public abstract class BaseMessageProcessor implements MessageProcessor {
      *            The message type a message processor can handle.
      */
     protected BaseMessageProcessor(final ResponseMessageSender responseMessageSender,
-            final MessageProcessorMap messageProcessorMap,
-            final MessageType messageType,
+            final MessageProcessorMap messageProcessorMap, final MessageType messageType,
             final ComponentType componentType) {
         this.responseMessageSender = responseMessageSender;
         this.messageProcessorMap = messageProcessorMap;
@@ -109,17 +108,19 @@ public abstract class BaseMessageProcessor implements MessageProcessor {
     protected void handleError(final Exception e, final String correlationUid, final String organisationIdentification,
             final String deviceIdentification, final String messageType, final int messagePriority) {
         LOGGER.info("handeling error: {} for message type: {}", e.getMessage(), messageType);
-        OsgpException osgpException = null;
-        if (e instanceof OsgpException) {
-            osgpException = (OsgpException) e;
-        } else {
-            osgpException = new TechnicalException(componentType, "An unknown error occurred", e);
-        }
+        final OsgpException osgpException = osgpExceptionOf(e);
 
         final ResponseMessage responseMessage = ResponseMessage.newResponseMessageBuilder()
                 .withCorrelationUid(correlationUid).withOrganisationIdentification(organisationIdentification)
                 .withDeviceIdentification(deviceIdentification).withResult(ResponseMessageResultType.NOT_OK)
                 .withOsgpException(osgpException).withDataObject(e).withMessagePriority(messagePriority).build();
         this.responseMessageSender.send(responseMessage);
+    }
+
+    private OsgpException osgpExceptionOf(Exception e) {
+        if (e instanceof OsgpException) {
+            return  (OsgpException) e;
+        }
+        return new TechnicalException(componentType, "An unknown error occurred", e);
     }
 }

--- a/shared/src/main/java/org/opensmartgridplatform/shared/infra/jms/BaseNotificationMessageProcessor.java
+++ b/shared/src/main/java/org/opensmartgridplatform/shared/infra/jms/BaseNotificationMessageProcessor.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2017 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.shared.infra.jms;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.opensmartgridplatform.shared.exceptionhandling.ComponentType;
+import org.opensmartgridplatform.shared.exceptionhandling.OsgpException;
+import org.opensmartgridplatform.shared.exceptionhandling.TechnicalException;
+
+/**
+ * Base class for MessageProcessor implementations. Each MessageProcessor
+ * implementation should be annotated with @Component. Further the MessageType
+ * the MessageProcessor implementation can process should be passed in at
+ * construction. The Singleton instance is added to the HashMap of
+ * MessageProcessors after dependency injection has completed.
+ */
+public abstract class BaseNotificationMessageProcessor implements MessageProcessor {
+
+    /**
+     * Logger for this class.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(BaseNotificationMessageProcessor.class);
+
+    /**
+     * This is the message sender needed for the message processor implementation to
+     * handle an error.
+     */
+    protected NotificationResponseMessageSender responseMessageSender;
+
+    /**
+     * The map of message processor instances.
+     */
+    protected MessageProcessorMap messageProcessorMap;
+
+    /**
+     * The message types that a message processor implementation can handle.
+     */
+    protected List<MessageType> messageTypes = new ArrayList<>();
+
+    /**
+     * Construct a message processor instance by passing in the message type.
+     *
+     * @param messageType
+     *            The message type a message processor can handle.
+     */
+    protected BaseNotificationMessageProcessor(final NotificationResponseMessageSender responseMessageSender,
+            final MessageProcessorMap messageProcessorMap, final MessageType messageType) {
+        this.responseMessageSender = responseMessageSender;
+        this.messageProcessorMap = messageProcessorMap;
+        this.messageTypes.add(messageType);
+    }
+
+    /**
+     * In case a message processor instance can process multiple message types, a
+     * message type can be added.
+     *
+     * @param messageType
+     *            The message type a message processor can handle.
+     */
+    protected void addMessageType(final MessageType messageType) {
+        this.messageTypes.add(messageType);
+    }
+
+    /**
+     * Initialization function executed after dependency injection has finished.
+     * The MessageProcessor Singleton is added to the HashMap of
+     * MessageProcessors.
+     */
+    @PostConstruct
+    public void init() {
+        for (final MessageType messageType : this.messageTypes) {
+            this.messageProcessorMap.addMessageProcessor(messageType, this);
+        }
+    }
+
+    /**
+     * In case of an error, this function can be used to send a response containing
+     * the exception to the web-service-adapter.
+     *
+     * @param e
+     *            The exception.
+     * @param correlationUid
+     *            The correlation UID.
+     * @param organisationIdentification
+     *            The organisation identification.
+     * @param deviceIdentification
+     *            The device identification.
+     * @param messageType
+     *            The message type.
+     */
+    protected void handleError(final Exception e, final String correlationUid, final String organisationIdentification,
+            final String deviceIdentification, final String messageType) {
+        LOGGER.info("handeling error: {} for message type: {}", e.getMessage(), messageType);
+        final OsgpException osgpException = new TechnicalException(ComponentType.UNKNOWN, "An unknown error occurred",
+                e);
+        final ResponseMessage responseMessage = ResponseMessage.newResponseMessageBuilder()
+                .withCorrelationUid(correlationUid).withOrganisationIdentification(organisationIdentification)
+                .withDeviceIdentification(deviceIdentification).withResult(ResponseMessageResultType.NOT_OK)
+                .withOsgpException(osgpException).withDataObject(e).build();
+        this.responseMessageSender.send(responseMessage, messageType);
+    }
+}


### PR DESCRIPTION
- Move MessageProcessor base classes from Platform to Shared, so they can be reused in all value streams.
- Mark DeviceFuntionDto as deprecated since it duplicates MessageType.